### PR TITLE
feat: enable making private topic

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -35,6 +35,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
+			private: data.private,
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -140,4 +140,8 @@ function modifyTopic(topic, fields) {
 			};
 		});
 	}
+
+	if (topic.hasOwnProperty('private')) {
+		topic.private = topic.private === 'true';
+	}
 }

--- a/test/topics.js
+++ b/test/topics.js
@@ -50,7 +50,7 @@ describe('Topic\'s', () => {
 			categoryId: categoryObj.cid,
 			title: 'Test Topic Title',
 			content: 'The content of test topic',
-			private: true
+			private: true,
 		};
 	});
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -50,6 +50,7 @@ describe('Topic\'s', () => {
 			categoryId: categoryObj.cid,
 			title: 'Test Topic Title',
 			content: 'The content of test topic',
+			private: true
 		};
 	});
 
@@ -386,6 +387,7 @@ describe('Topic\'s', () => {
 				title: topic.title,
 				content: topic.content,
 				cid: topic.categoryId,
+				private: topic.private,
 			}, (err, result) => {
 				if (err) {
 					return done(err);
@@ -405,6 +407,7 @@ describe('Topic\'s', () => {
 				assert(typeof topicData.uid === 'number');
 				assert(typeof topicData.cid === 'number');
 				assert(typeof topicData.mainPid === 'number');
+				assert(typeof topicData.private === 'boolean');
 
 				assert(typeof topicData.timestamp === 'number');
 				assert.strictEqual(topicData.postcount, 1);
@@ -415,6 +418,7 @@ describe('Topic\'s', () => {
 				assert.strictEqual(topicData.deleted, 0);
 				assert.strictEqual(topicData.locked, 0);
 				assert.strictEqual(topicData.pinned, 0);
+				assert.strictEqual(topicData.private, true);
 				done();
 			});
 		});


### PR DESCRIPTION
### Context
We are adding a private field to the topic object so the users would be able to make a private topic. This is an essential step to fulfill user story #10. 

### Description
Adds new boolean "private" field to the topic to denote if a post should be private.

### Changes in the codebase
Adds new "private" field to the create topic api in [src/topics/create.js](https://github.com/CMU-313/nodebb-fall-2025-mynn/pull/31/files#diff-1a10bbaaef0372571a4c28af41e91f9704cf90a486ed53c66bf4c206b9156fbc).
Converts the "private" field to a boolean in [src/topics/create.js](https://github.com/CMU-313/nodebb-fall-2025-mynn/pull/31/files#diff-1a10bbaaef0372571a4c28af41e91f9704cf90a486ed53c66bf4c206b9156fbc).

### Testing
Added tests to verify the type of the "private" field and its value after creating a topic.

Run `npm run test`. Or Run `npm run test test/topics.js` to test only the file where the change was made.

fixes #15 