### PR TITLE
refactor(helpers): simplify getVisibleCategories with shouldShowCategory

### DIFF
--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -312,9 +312,10 @@ helpers.getVisibleCategories = async function (params) {
 			return false;
 		}
 		const hasVisibleChildren = checkVisibleChildren(c, cidToAllowed, cidToWatchState, states);
+		const shouldShowCategory = showLinks || !c.link;
 		const isCategoryVisible = (
 			cidToAllowed[c.cid] &&
-			(showLinks || !c.link) &&
+			shouldShowCategory &&
 			!c.disabled &&
 			states.includes(cidToWatchState[c.cid])
 		);


### PR DESCRIPTION
**Context**
- getVisibleCategories function in src/controllers/helpers.js had a complex binary expression that increased cognitive complexity & made the logic harder to follow

**Description**
- This PR extracts the expression of (showLinks || !c.link) into a var shouldShowCategory. This improves readability and maintainability without altering functionality

**Changes**
- Introduced shouldShowCategory variable to replace inline condition (showLinks || !c.link)

**Testing**
- Verified the same function via the UI by going to /recent and selecting All Categories
- Confirmed expected category visibility behavior remained intact
- Ran qlty smells --no-snippets src/controllers/helpers.js to confirm reduced reported complexity

**Additional Information**
- No breaking changes introduced