### PR TITLE
feat: add a "private" front-end label that is only visible for private posts

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl
@@ -29,6 +29,9 @@
 				</h1>
 
 				<div class="topic-info d-flex gap-2 align-items-center flex-wrap {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
+				    {{{if private}}}
+				 		<span class="badge badge border border-gray-300 text-body">Private</span>
+					{{{end}}}
 					<span component="topic/labels" class="d-flex gap-2 {{{ if (!scheduled && (!pinned && (!locked && (!icons.length && (!oldCid || (oldCid == "-1")))))) }}}hidden{{{ end }}}">
 						<span component="topic/scheduled" class="badge badge border border-gray-300 text-body {{{ if !scheduled }}}hidden{{{ end }}}">
 							<i class="fa fa-clock-o"></i> [[topic:scheduled]]


### PR DESCRIPTION
Context
This feature is for addressing the concerns of user story #10, which called for the creation of private posts. Specifically, for the creation of a label in the topic window that indicates whether the given topic is private or public based on the "private" field that was added to topicData in the back-end. 

Description
This feature consists of a label that reads "private" in the front-end of NodeBB that appears in the topic UI, directly below the title of the topic, and to the left of the category. If the topic has the private field marked true in its topicData, the label will appear when the topic is clicked on. If the topic is not flagged as private with the back-end private field, the label does not appear. Note, however, that at this time, the label's appearance cannot be triggered by another front-end element. That is, there is no front-end element to change the private field in topicData yet, however, there is a front-end element that can respond to the value of the private field (the label). 

Changes

Added UI element to vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl that is conditioned on whether the topic is private or not. 

Testing

On topics created with the private field set to true, the label is visible. 
On topics created with the private field set to false, the label is not visible. 

Example of a post created with the private field set to true: 
<img width="3024" height="1308" alt="Screenshot 2025-09-22 at 12 28 04 AM" src="https://github.com/user-attachments/assets/907eee6d-a3d8-43fb-b709-61a8d34ec2d3" />
Example of a post created with the private field set to false: 
<img width="3018" height="1292" alt="Screenshot 2025-09-22 at 12 28 11 AM" src="https://github.com/user-attachments/assets/41af7a88-66b6-4dcf-aef2-c2199cd3d42d" />

Fixes #17 


 