### PR TITLE
test(db, privileges): Add comprehensive database and privilege tests for private topic functionality

### DIFF
--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -142,6 +142,8 @@ function modifyTopic(topic, fields) {
 	}
 
 	if (topic.hasOwnProperty('private')) {
-		topic.private = topic.private === 'true';
+		// convert redis string/ num values to boolean
+		// need to handle string values
+		topic.private = topic.private === 1 || topic.private === '1' || topic.private === true || topic.private === 'true';
 	}
 }

--- a/test/database/hash.js
+++ b/test/database/hash.js
@@ -678,4 +678,75 @@ describe('Hash methods', () => {
 			assert.equal(d[1].newField, -5);
 		});
 	});
+
+
+	// tests for database implementation with private field
+	describe('private field for topics', () => {
+		it('should store private flag as 1 for private topics', async () => {
+			await db.setObjectField('topic:private1', 'private', 1);
+			const privateValue = await db.getObjectField('topic:private1', 'private');
+			assert.strictEqual(privateValue, '1');
+		});
+
+		it('should store private flag as 0 for public topics', async () => {
+			await db.setObjectField('topic:public1', 'private', 0);
+			const privateValue = await db.getObjectField('topic:public1', 'private');
+			assert.strictEqual(privateValue, '0');
+		});
+
+		it('should return null when private field is missing', async () => {
+			await db.setObject('topic:legacy1', { tid: 'legacy1', title: 'Legacy Topic' });
+			const privateValue = await db.getObjectField('topic:legacy1', 'private');
+			assert.strictEqual(privateValue, null);
+		});
+
+		it('should handle complete topic data with private field', async () => {
+			await db.setObject('topic:complete1', {
+				tid: 'complete1',
+				uid: 1,
+				title: 'Complete Test Topic',
+				private: 1,
+			});
+
+			const topicData = await db.getObject('topic:complete1');
+			assert.strictEqual(topicData.private, '1');
+			assert.strictEqual(topicData.title, 'Complete Test Topic');
+		});
+
+		it('should update private field correctly', async () => {
+			await db.setObjectField('topic:update1', 'private', 0);
+			let value = await db.getObjectField('topic:update1', 'private');
+			assert.strictEqual(value, '0');
+
+			await db.setObjectField('topic:update1', 'private', 1);
+			value = await db.getObjectField('topic:update1', 'private');
+			assert.strictEqual(value, '1');
+		});
+
+		it('should check if private field exists', async () => {
+			await db.setObjectField('topic:exists1', 'private', 1);
+			
+			const exists = await db.isObjectField('topic:exists1', 'private');
+			assert.strictEqual(exists, true);
+
+			const notExists = await db.isObjectField('topic:exists1', 'nonexistent');
+			assert.strictEqual(notExists, false);
+		});
+
+		it('should delete private field', async () => {
+			await db.setObject('topic:delete1', { private: 1, title: 'Test' });
+			
+			let exists = await db.isObjectField('topic:delete1', 'private');
+			assert.strictEqual(exists, true);
+
+			await db.deleteObjectField('topic:delete1', 'private');
+			
+			exists = await db.isObjectField('topic:delete1', 'private');
+			assert.strictEqual(exists, false);
+
+			// Verify other fields remain
+			const titleExists = await db.isObjectField('topic:delete1', 'title');
+			assert.strictEqual(titleExists, true);
+		});
+	});
 });


### PR DESCRIPTION
## Context
This is a follow-up to PR #34, which introduced private topic flag support in the database (user story #10, feature #39). The earlier implementation was only verified through Redis CLI checks. This PR adds full test coverage & a small boolean conversion fix

## Description
Adds two Mocha test suites to validate the private topic feature end-to-end:
- Database Layer: verifies Redis hash operations for the private flag (storage, retrieval, mutability, edge cases, cleanup)
- Privilege Layer: verifies access control logic so only authors/admins can view private topics, with correct filtering in topic lists
- Includes additional fix to normalize boolean conversion for the private flag in src/topics/data.js

## Changes
- Added 7 database tests within existing test/database/hash.js for private field storage, retrieval, legacy compatibility, mutability, CRUD helpers, and cleanup
- Added 4 privilege integration tests (test/topics.js) for boolean conversion, access control (author/admin/other/guest), topic filtering, and multi-user scenarios
- Fixed boolean conversion in src/topics/data.js to handle multiple input types (1, '1', true, 'true') and ensure consistent output

## Testing
We extended existing Mocha test files (test/database/hash.js, test/topics.js) with new cases covering private flag storage, access control, and boolean conversion. Running the full suite with npm test confirmed all new and existing tests pass.

Successful output from npm run test test/database/hash.js:
<img width="591" height="132" alt="image" src="https://github.com/user-attachments/assets/9aa8c42d-aca0-4095-9d8a-c097152b3bcf" />

Successful output from npm run test test/topics.js:
<img width="598" height="130" alt="image" src="https://github.com/user-attachments/assets/d08bb78e-1e04-4144-803b-e3bb60773b71" />

Successful output from npm run test
<img width="933" height="221" alt="image" src="https://github.com/user-attachments/assets/8ba2ab7b-eb06-44aa-b361-a833139e27c3" />


## Additional Information
Closes #39
