### PR TITLE
feat: pass if the post should be private to the create topic api call

### DIFF
--- a/vendor/nodebb-plugin-composer-default-10.2.51/static/lib/composer.js
+++ b/vendor/nodebb-plugin-composer-default-10.2.51/static/lib/composer.js
@@ -670,6 +670,7 @@ define('composer', [
 		var titleEl = postContainer.find('.title');
 		var bodyEl = postContainer.find('textarea');
 		var thumbEl = postContainer.find('input#topic-thumb-url');
+		var privateEl = postContainer.find('input#composer-private');
 		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		const submitBtn = postContainer.find('.composer-submit');
 
@@ -737,6 +738,7 @@ define('composer', [
 				cid: categoryList.getSelectedCid(),
 				tags: tags.getTags(post_uuid),
 				timestamp: scheduler.getTimestamp(),
+				private: privateEl ? privateEl.is(':checked') : false,
 			};
 		} else if (action === 'posts.reply') {
 			route = `/topics/${postData.tid}`;


### PR DESCRIPTION
### Context
In the frontend, there is a checkbox to toggle whether a topic should be private. In the backend, the create topic API supports taking a `private` field as input to mark topics as private.

### Description
This PR integrates the frontend and backend components mentioned in the context section by passing the correct `private` flag from the frontend to the backend based on if the checkbox is selected.

### Changes in the codebase
- Retrieve the checkbox element in the frontend by its type and id. 
- Read its checked state and pass the state to the create topic API call as the private field.

### Testing
As shown below, if the checkbox is **not** selected, then the created topic is **not** private.

https://github.com/user-attachments/assets/4fa84766-3c70-4055-b4e8-3f5ff57c8fd3


As shown below, if the checkbox is selected, then the created topic will be labeled as private.

https://github.com/user-attachments/assets/4df6789f-3061-4a06-9c01-e704dd92d7da

### Issue Reference
fixes #29 