### PR TITLE
Matthew/feat topic privacy UI

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -254,5 +254,8 @@
 	"thumb-image": "Topic thumbnail image",
 
 	"announcers": "Shares",
-	"announcers-x": "Shares (%1)"
+	"announcers-x": "Shares (%1)",
+
+	"make_private": "Make Private",
+    "make_public": "Make Public"
 }

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -224,5 +224,7 @@
     "unread-posts-link": "Unread posts link",
     "thumb-image": "Topic thumbnail image",
     "announcers": "Shares",
-    "announcers-x": "Shares (%1)"
+    "announcers-x": "Shares (%1)",
+    "make_private": "Make Private",
+    "make_public": "Make Public"
 }

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/privacy-button.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/privacy-button.tpl
@@ -1,0 +1,6 @@
+{{{ if (privileges.isAdminOrMod && !private) }}}
+<a component="topic/toggle-private" href="#" class="d-flex gap-2 align-items-center btn btn-sm btn-ghost fw-semibold" data-tid="{tid}" data-private="{topic.private}">
+    <i class="fa fa-fw fa-lock text-primary"></i>
+    <span class="d-none d-md-block text-truncate text-nowrap">[[topic:make_private]]</span>
+</a>
+{{{ end }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl
@@ -106,6 +106,7 @@
 									<!-- IMPORT partials/topic/watch.tpl -->
 									<!-- IMPORT partials/topic/sort.tpl -->
 									<!-- IMPORT partials/topic/tools.tpl -->
+									<!-- IMPORT partials/topic/privacy-button.tpl -->
 								</div>
 								{{{ end }}}
 								{{{ if config.theme.topicSidebarTools }}}<hr class="my-0" style="min-width: 170px;"/>{{{ end }}}


### PR DESCRIPTION
### Context
This is a follow-up to the private topic database implementation, adding the UI component for issue #24. This provides admin roles with a visual toggle for topic privacy status on user posted topic threads.

### Description
Adds a 'Make Private' button to the topic sidebar that appears only for admins/ mods. The button integrates into the Harmony theme's topic tools sidebar and is based on existing private topic infrastructure.

This includes:
- **Admin-only visibility:** Button appears only for users with privileges.isAdminOrMod
- **Dynamic content:** Shows Make Private button for topics that are currently public
- **Theme/ codebase integration:** Follows Harmony design patterns with responsive UI layout and code setup
- **Internationalization:** Uses translation keys for proper language support

### Changes
- **Template Integration:** Added privacy button import to vendor/nodebb-theme-harmony-2.1.15/templates/topic.tpl in topic tools sidebar
- **Privacy Button Partial:** Created vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/privacy-button.tpl with conditional rendering and proper data attributes
- **Internationalization:** Added make_private, make_public, private-topic keys to both public/language/en-GB/topic.json and in public/language/en-US/topic.json

### Testing
Confirmed that:
- Button visibility restricted to admin roles only when viewing an existing public post by a user
- Correct icon and text display based on topic privacy status

### Screenshots

<img width="941" height="584" alt="image" src="https://github.com/user-attachments/assets/4302ee54-ba68-4f0c-bfab-a00ab06d9f96" />

The above screenshot shows the ‘Make Private’ button on the topic sidebar. The currently logged in user is admin and this is viewing a sample user’s public post.


<img width="939" height="591" alt="image" src="https://github.com/user-attachments/assets/d14c04c5-526a-4237-93f2-5c0db5986eec" />

The above screenshot shows an existing private post but does not allow for the currently logged in admin to make it public. This was an intentional choice so as to not allow any deliberate private posts to be made public under any circumstances.


<img width="936" height="580" alt="image" src="https://github.com/user-attachments/assets/9458ab3c-33c4-4f6f-94d3-9407f4a23038" />

The above screenshot shows another regular user who can view the public post but does not have access to the ‘Make Private’ sidebar button.

### Additional Information
- Closes Issue #24 
- Next steps: JavaScript event handlers and API endpoint integration
