### PR TITLE
feat: only show "Make Private" checkbox when creating a new topic and not when editing and not when editing

### DIFF
--- a/vendor/nodebb-plugin-composer-default-10.2.51/static/templates/composer.tpl
+++ b/vendor/nodebb-plugin-composer-default-10.2.51/static/templates/composer.tpl
@@ -27,7 +27,7 @@
 			<!-- IMPORT partials/composer-formatting.tpl -->
 
 			<!-- Private Post Option -->
-			{{{ if isTopicOrMain }}}
+			{{{ if (isTopicOrMain && !isEditing) }}}
 			<div class="form-group mt-2">
 				<div class="form-check">
 					<input type="checkbox" class="form-check-input" id="composer-private" name="private">


### PR DESCRIPTION
### Context
In issue #12, we added a "Make Private" checkbox to let the user decide if they want the new topic they are creating to be private. However, this checkbox also shows up when editing a topic, which is undesirable since the user should not be able to change if their topic is private after creation. 

### Description
The user now will only see the "Make Private" checkbox when creating a new topic and not when editing and not when editing

### Changes in the codebase
Using a conditional to only show the"Make Private" checkbox if the user is not editing the topic. [static/templates/composer.tpl](https://github.com/CMU-313/nodebb-fall-2025-mynn/blob/ad6064a9db121bca6ff67aa6b4c42c93f2119ca7/vendor/nodebb-plugin-composer-default-10.2.51/static/templates/composer.tpl).

### Testing
The following screenshot shows that the "Make Private" checkbox is visible when creating a new topic
<img width="1468" height="790" alt="image" src="https://github.com/user-attachments/assets/c5afcd81-ba7c-4bec-ad61-0430c78d39c3" />

The following screenshot shows that the "Make Private" checkbox is **not** visible when editing an existing topic
<img width="1468" height="790" alt="image" src="https://github.com/user-attachments/assets/bc954006-d2ea-456b-8730-193577b211c5" />

fixes #42 
