### PR TITLE
WIP: Add support for the back-end to handle requests from "Make Private" button clicks 

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -229,7 +229,6 @@ define('forum/topic', [
 			const isPrivate = button.data('private');
 	
 			try {
-				// Send a PUT request to toggle the private field
 				const response = await fetch(`/api/topic/${tid}/toggle-privacy`, {
 					method: 'PUT',
 					headers: { 'Content-Type': 'application/json' },
@@ -238,7 +237,6 @@ define('forum/topic', [
 	
 				if (response.ok) {
 					const result = await response.json();
-					// Update the button's state and text
 					button.data('private', result.private);
 					button.find('span').text(result.private ? 'Make Public' : 'Make Private');
 					button.find('i').toggleClass('fa-lock fa-unlock');

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -360,6 +360,31 @@ function addOGImageTag(res, image) {
 	}
 }
 
+topicsController.togglePrivate = async function (req, res, next) {
+	try {
+		const tid = req.params.topic_id;
+		const { private: isPrivate } = req.body;
+		if (!utils.isNumber(tid)) {
+			return next();
+		}
+		if (typeof isPrivate !== 'boolean') {
+			return res.status(400).json({ error: 'Invalid private value' });
+		}
+
+		const canEdit = await privileges.topics.can('topics:edit', tid, req.uid);
+		if (!canEdit) {
+			return res.status(403).json({ error: '[[error:no-privileges]]' });
+		}
+
+		await topics.setTopicField(tid, 'private', isPrivate);
+
+		res.status(200).json({ private: isPrivate });
+	} catch (err) {
+		console.error('Error toggling topic privacy:', err);
+		res.status(500).json({ error: 'Internal server error' });
+	}
+};
+
 topicsController.teaser = async function (req, res, next) {
 	const tid = req.params.topic_id;
 	if (!utils.isNumber(tid)) {


### PR DESCRIPTION
### Context
To address issue #24, a button was created to appear on the page of any public topic that says "Make Private" on it which appears only to admins/moderators. The goal of implementing such a button was to allow admins/moderators to press the button on any given public topic to make it private. This attempts to provide the implementation of such a feature.  

### Description
Adds functionality to the "Make Private" button that admins/moderators can see as a part of issue #24, such that pressing the button on a given topic page on the front-end will make a request to the back-end to modify the private field of the topic. 

### Changes
- **Button Click Event Handler** Added a function to public/src/client/topic.js called addPrivacyToggleHandler() which listens for a click to the button, then creates an HTTP request to the back-end to alter the private field of the topic in the back-end. 
- **API Endpoint** Added New API Endpoint for Privacy Toggling 
-  **Toggling Private Field in Back-End** Added a function to src/controllers/topics.js called topicsController.togglePrivate() that sets the private field in the back-end.  

### Testing
- As of now, manual testing through clicking the front-end element and inspecting the network activity reveals that the HTTP requests are being made each time the button is clicked, however, they are never handled. 
- Inspecting the requests confirmed that HTTP requests are being made to the correct URL
- As of now, no automated unit tests for the integration are possible as the HTTP requests are never processed. 

### Additional Information
- Fixes #27 
- Next steps: Ensure HTTP requests aren't being lost, and the Back-End can get a chance to handle the request
