### PR TITLE
chore: install JavaScript Standard Style package (StandardJS)

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -35,6 +35,7 @@
         "@isaacs/ttlcache": "1.4.1",
         "@nodebb/spider-detector": "2.0.3",
         "@popperjs/core": "2.11.8",
+        "@socket.io/redis-adapter": "8.3.0",
         "@textcomplete/contenteditable": "0.1.13",
         "@textcomplete/core": "0.1.13",
         "@textcomplete/textarea": "0.1.13",
@@ -77,6 +78,7 @@
         "helmet": "7.2.0",
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",
+        "ioredis": "5.6.1",
         "ipaddr.js": "2.2.0",
         "jquery": "3.7.1",
         "jquery-deserialize": "2.0.0",
@@ -122,7 +124,6 @@
         "postcss-clean": "1.2.0",
         "progress-webpack-plugin": "1.0.16",
         "prompt": "1.3.0",
-        "ioredis": "5.6.1",
         "rimraf": "6.0.1",
         "rss": "1.2.2",
         "rtlcss": "4.3.0",
@@ -135,7 +136,6 @@
         "sitemap": "8.0.0",
         "socket.io": "4.8.1",
         "socket.io-client": "4.8.1",
-        "@socket.io/redis-adapter": "8.3.0",
         "sortablejs": "1.15.6",
         "spdx-license-list": "6.10.0",
         "terser-webpack-plugin": "5.3.14",
@@ -159,9 +159,9 @@
         "@apidevtools/swagger-parser": "10.1.0",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-angular": "19.8.1",
-        "coveralls": "3.1.1",
         "@eslint/js": "9.26.0",
         "@stylistic/eslint-plugin-js": "4.4.0",
+        "coveralls": "3.1.1",
         "eslint-config-nodebb": "1.1.5",
         "eslint-plugin-import": "2.31.0",
         "grunt": "1.6.1",
@@ -173,7 +173,8 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "17.1.0",
-        "smtp-server": "3.13.6"
+        "smtp-server": "3.13.6",
+        "standard": "^17.1.2"
     },
     "optionalDependencies": {
         "sass-embedded": "1.88.0"


### PR DESCRIPTION
### Installation of the Tool

The npm package `standard` for JavaScript Standard Style is added on line 177 of the `package.json` file located in the `install` folder. The other changes in the file involve sorting the packages alphabetically.   

### Artifacts of Running the Tool

This [file](https://github.com/user-attachments/files/23059353/output.txt) contains the output of running the command `npx standard "src/**/*.js" "test/**/*.js" > output.txt` on the project. We chose to only run the tool only on the `src` and `test` folders to avoid unnecessary warnings from folder like `build`.

Additionally, the following screenshot shows running the tool in the terminal
<img width="1470" height="832" alt="image" src="https://github.com/user-attachments/assets/eeff9295-53de-4bc3-81c7-f1a4c3312021" />